### PR TITLE
Add 'pwd' utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Includes
         * `frange file.txt 1 10` (prints first 10 lines)
         * `frange file.txt 20` (prints starting from line 20 to the end of the file)
         * `frange file.txt 20 10` (prints 10 lines starting from line 20)
+* `pwd` - print working directory (UNIX-style shortcut for print(pwd()))
+    * example: `pwd`
 
 ## Usage
 

--- a/utils/pwd.lua
+++ b/utils/pwd.lua
@@ -1,0 +1,2 @@
+cd(env().path)
+?pwd()


### PR DESCRIPTION
Kinda useless tbh, but in learning the picotron system I was trying a few well-known UNIX utils and `pwd` stood out as one that was missing.

Thankfully it's already implemented, so `pwd` acts as a shortcut to `print(pwd())`